### PR TITLE
Refresh tokens

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'bcrypt', '~> 3.1.7'
 gem 'rack-cors'
 
 # Auth
-gem 'credible', github: 'thombruce/credible', branch: 'master' # TODO: Investigate failure to load gem from GitHub in GitHub Actions
+gem 'credible', github: 'thombruce/credible', branch: 'refresh-tokens' # TODO: Investigate failure to load gem from GitHub in GitHub Actions
 gem 'warden' # TODO: Investigate. Currently fails without explicit inclusion.
 gem 'pundit'
 # Use JSON Web Tokens

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/thombruce/credible.git
-  revision: 2b676b440467a402d65d17e3f1ff9799e822a88c
-  branch: master
+  revision: 3f177158f66aa2b1fa07aa8c689a742df87bde0a
+  branch: refresh-tokens
   specs:
     credible (0.11.0)
       bcrypt (~> 3.1.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/thombruce/credible.git
-  revision: 3f177158f66aa2b1fa07aa8c689a742df87bde0a
+  revision: 1215a6e75033362e0ea66764c441a404ff3cbffa
   branch: refresh-tokens
   specs:
     credible (0.11.0)

--- a/app/javascript/src/App.vue
+++ b/app/javascript/src/App.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   div
     component(:is="layout")
-      router-view(v-if="currentUser")
+      router-view(v-if="sessionLoaded")
 </template>
 
 <script>

--- a/app/javascript/src/App.vue
+++ b/app/javascript/src/App.vue
@@ -12,10 +12,6 @@ export default {
     layout() {
       return (this.$route.meta.layout || default_layout) + '-layout'
     }
-  },
-  created() {
-    // See mixins/settings.js
-    this.fetchSettings()
   }
 }
 </script>

--- a/app/javascript/src/App.vue
+++ b/app/javascript/src/App.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   div
     component(:is="layout")
-      router-view
+      router-view(v-if="currentUser")
 </template>
 
 <script>
@@ -11,6 +11,14 @@ export default {
   computed: {
     layout() {
       return (this.$route.meta.layout || default_layout) + '-layout'
+    }
+  },
+  created: function () {
+    this.fetchSession()
+  },
+  methods: {
+    fetchSession () {
+      this.$store.dispatch('tokens/init')
     }
   }
 }

--- a/app/javascript/src/axios.js
+++ b/app/javascript/src/axios.js
@@ -1,12 +1,14 @@
 import axios from 'axios'
 
+import store from './store'
+
 // Default settings
 axios.defaults.baseURL = '/auth'
 axios.defaults.headers.common['Accept'] = 'application/json'
 
 // Interceptor Functions
 const requestInterceptor = (request) => {
-  let token = localStorage.getItem('user-token')
+  let token = store.state.tokens.accessToken
 
   if (token) {
     request.headers['Authorization'] = `Bearer ${ token }`
@@ -17,7 +19,7 @@ const requestInterceptor = (request) => {
 
 const responseErrorInterceptor = (error) => {
   if (error.response.status === 401) {
-    localStorage.removeItem('user-token')
+    localStorage.removeItem('refresh-token')
     window.location = '/login'
   } else {
     return Promise.reject(error)

--- a/app/javascript/src/mixins/session.js
+++ b/app/javascript/src/mixins/session.js
@@ -1,27 +1,10 @@
-const jwtDecode = require('jwt-decode')
-
 const session = {
-  data: function () {
-    return {
-      currentSession: null,
-      currentUser: null
-    }
-  },
-  created: function () {
-    // TODO: This whole mixin needs refactored to use the new store version
-    //       of currentSession. But this in particular is the big issue:
-    //       Because this is a global mixin, fetchSession will be ran when
-    //       EVERY component is created. That's dozens of times per page.
-    //       Leaving for now, as it doesn't hit the API, but do fix this.
-    this.fetchSession()
-  },
-  methods: {
-    fetchSession: function () {
-      var token = localStorage.getItem('user-token')
-      if (token) {
-        this.currentSession = jwtDecode(token).data
-        this.currentUser = this.currentSession.user
-      }
+  computed: {
+    currentSession () {
+      return this.$store.getters['tokens/currentSession']
+    },
+    currentUser () {
+      return this.$store.getters['tokens/currentUser']
     }
   }
 }

--- a/app/javascript/src/mixins/session.js
+++ b/app/javascript/src/mixins/session.js
@@ -1,5 +1,8 @@
 const session = {
   computed: {
+    sessionLoaded () {
+      return this.$store.state.tokens.sessionLoaded
+    },
     currentSession () {
       return this.$store.getters['tokens/currentSession']
     },

--- a/app/javascript/src/routes.js
+++ b/app/javascript/src/routes.js
@@ -24,7 +24,7 @@ router.beforeEach((to, from, next) => {
   // redirect to login page if not logged in and trying to access a restricted page
   const publicPages = ['login_path', 'signup_path', 'confirm_path', 'reset_password_path']
   const authRequired = !publicPages.includes(to.name)
-  const loggedIn = localStorage.getItem('user-token')
+  const loggedIn = localStorage.getItem('refresh-token')
 
   if (authRequired && !loggedIn) {
     return next('/login')

--- a/app/javascript/src/store/authentication/index.js
+++ b/app/javascript/src/store/authentication/index.js
@@ -2,56 +2,53 @@ import { authAPI as axios } from '../../axios'
 
 import account from './account'
 
-const jwtDecode = require('jwt-decode')
-
-const state = () => ({
-  currentSession: {}
-})
-
 const actions = {
-  login({ state, commit }, payload) {
+  login({ dispatch, rootGetters }, payload) {
     return axios
       .post('/login', payload)
       .then((res) => {
-        if (res.data.jwt) {
-          localStorage.setItem('user-token', res.data.jwt)
-        }
-        commit('setSession', res.data.jwt)
-        return state.currentSession
+        let refreshToken = res.data.refresh_token,
+            accessToken = res.data.access_token
+
+        dispatch('tokens/create', { refreshToken, accessToken }, { root: true })
+
+        return rootGetters.tokens.currentSession
       })
       .catch((error) => {
         return Promise.reject(error.response.data)
       })
   },
-  signup({ state, commit }, payload) {
+  signup({ dispatch, rootGetters }, payload) {
     return axios
       .post('/signup', payload)
       .then((res) => {
-        if (res.data.jwt) {
-          localStorage.setItem('user-token', res.data.jwt)
-        }
-        commit('setSession', res.data.jwt)
-        return state.currentSession
+        let refreshToken = res.data.refresh_token,
+            accessToken = res.data.access_token
+
+        dispatch('tokens/create', { refreshToken, accessToken }, { root: true })
+
+        return rootGetters.tokens.currentSession
       })
       .catch((error) => {
         return Promise.reject(error.response.data)
       })
   },
-  confirm({ state, commit }, params) {
+  confirm({ dispatch, rootGetters }, params) {
     return axios
       .get('/confirm/' + params.confirmation_token, { params: { email: params.email } })
       .then((res) => {
-        if (res.data.jwt) {
-          localStorage.setItem('user-token', res.data.jwt)
-        }
-        commit('setSession', res.data.jwt)
-        return state.currentSession
+        let refreshToken = res.data.refresh_token,
+            accessToken = res.data.access_token
+
+        dispatch('tokens/create', { refreshToken, accessToken }, { root: true })
+
+        return rootGetters.tokens.currentSession
       })
       .catch((error) => {
         return Promise.reject(error.response.data)
       })
   },
-  resetPassword({ state, commit }, payload) {
+  resetPassword({}, payload) {
     return axios
       .post('/reset_password', payload)
       .then((res) => {
@@ -61,12 +58,12 @@ const actions = {
         return Promise.reject(error.response.data)
       })
   },
-  signout({ commit }) {
+  signout({ dispatch }) {
     return axios
       .delete('/signout')
       .then((res) => {
-        localStorage.removeItem('user-token')
-        commit('endSession')
+        dispatch('tokens/destroy', { root: true })
+        return true
       })
       .catch((error) => {
         console.log(error)
@@ -74,20 +71,9 @@ const actions = {
   }
 }
 
-const mutations = {
-  setSession(state, payload) {
-    state.currentSession = jwtDecode(payload).data
-  },
-  endSession(state) {
-    state.currentSession = {}
-  }
-}
-
 const authentication = {
   namespaced: true,
-  state,
   actions,
-  mutations,
   modules: {
     account
   }

--- a/app/javascript/src/store/index.js
+++ b/app/javascript/src/store/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue/dist/vue.esm'
 import Vuex from 'vuex'
 Vue.use(Vuex)
 
+import tokens from './tokens'
 import authentication from './authentication'
 
 const state = () => ({
@@ -31,6 +32,7 @@ const store = new Vuex.Store({
   getters,
   actions,
   modules: {
+    tokens,
     authentication
   }
 })

--- a/app/javascript/src/store/tokens.js
+++ b/app/javascript/src/store/tokens.js
@@ -1,0 +1,79 @@
+import { authAPI as axios } from '../axios'
+
+const jwtDecode = require('jwt-decode')
+
+const state = () => ({
+  refreshToken: null,
+  accessToken: null
+})
+
+const getters = {
+  currentSession: (state) => {
+    if (state.accessToken) {
+      return jwtDecode(state.accessToken).data
+    } else {
+      return null
+    }
+  },
+  currentUser: (state, getters) => {
+    if (state.accessToken) {
+      return getters.currentSession.user
+    } else {
+      return null
+    }
+  }
+}
+
+const actions = {
+  init({ state, commit, dispatch }) {
+    let refreshToken = localStorage.getItem('refresh-token')
+    if (refreshToken) {
+      commit('insert', { refreshToken })
+      dispatch('refresh', refreshToken)
+    }
+    return state.accessToken
+  },
+  create({ state, commit }, { refreshToken, accessToken }) {
+    localStorage.setItem('refresh-token', refreshToken)
+    commit('insert', { refreshToken, accessToken })
+    return state.accessToken
+  },
+  destroy({ commit }) {
+    localStorage.removeItem('refresh-token')
+    commit('remove')
+    return true
+  },
+  refresh({ state, commit }, refreshToken) {
+    return axios
+      .post('/refresh', { refresh_token: refreshToken })
+      .then((res) => {
+        localStorage.setItem('refresh-token', res.data.refresh_token)
+        commit('insert', { refreshToken: res.data.refresh_token, accessToken: res.data.access_token })
+        return state.accessToken
+      })
+      .catch((error) => {
+        return Promise.reject(error.response.data)
+      })
+  }
+}
+
+const mutations = {
+  insert(state, { refreshToken, accessToken }) {
+    state.refreshToken = refreshToken
+    state.accessToken = accessToken
+  },
+  remove(state) {
+    state.refreshToken = null
+    state.accessToken = null
+  }
+}
+
+const tokens = {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations,
+}
+
+export default tokens

--- a/app/javascript/src/store/tokens.js
+++ b/app/javascript/src/store/tokens.js
@@ -3,6 +3,7 @@ import { authAPI as axios } from '../axios'
 const jwtDecode = require('jwt-decode')
 
 const state = () => ({
+  sessionLoaded: false,
   refreshToken: null,
   accessToken: null
 })
@@ -25,12 +26,13 @@ const getters = {
 }
 
 const actions = {
-  init({ state, commit, dispatch }) {
+  async init({ state, commit, dispatch }) {
     let refreshToken = localStorage.getItem('refresh-token')
     if (refreshToken) {
       commit('insert', { refreshToken })
-      dispatch('refresh', refreshToken)
+      await dispatch('refresh', refreshToken)
     }
+    commit('finish')
     return state.accessToken
   },
   create({ state, commit }, { refreshToken, accessToken }) {
@@ -65,6 +67,9 @@ const mutations = {
   remove(state) {
     state.refreshToken = null
     state.accessToken = null
+  },
+  finish(state) {
+    state.sessionLoaded = true
   }
 }
 


### PR DESCRIPTION
See also: https://github.com/thombruce/credible/pull/27

I've been muddling through these changes but I'm at a point where I'm happy. Still want to refactor the store, but I want to document some sound decisions...

We set a sessionLoaded state via a `finish` mutation (after an async `refresh` if token exists), and use that state to determine when we can load the router-view. This is important because router-view depends on logic that requires knowledge of the session.

```
// In Component
router-view(v-if="sessionLoaded")

// In tokens store
  finish(state) {
    state.sessionLoaded = true
  }
```

_Note: sessionLoaded is a computed property in sessions mixin._